### PR TITLE
add: script at package.json to run tests with only flag on

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",
-    "test": "npm run build && node --test ./test/*.test.js"
+    "test": "npm run build && node --test ./test/*.test.js",
+    "test-only": "npm run build && node --test-only ./test/*.test.js"
   },
   "dependencies": {
     "@scure/base": "^1.2.4"


### PR DESCRIPTION
### Summary
- Add a script to be able to run tests with `--test-only` flag on.

### Screenshots

Changes at `code.test.ts` to test the implementation:
<img width="790" alt="image" src="https://github.com/user-attachments/assets/03985e9a-5bbd-4f6f-b011-26a462dbbe8f" />

Console output by running `npm run test-only`:
<img width="946" alt="image" src="https://github.com/user-attachments/assets/46e0b417-9ae5-4051-b45d-cf4e733c8f39" />
