### PR TITLE
build: emit type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # npm installed local dependencies
 node_modules
 *.js
+*.d.ts
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "author": "RAILGUN Project Contributors",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "directories": {
     "test": "test"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["@railgun-reloaded/tsconfig/tsconfig"]
+  "extends": ["@railgun-reloaded/tsconfig/tsconfig"],
+  "compilerOptions": {
+    "declaration": true
+  }
 }


### PR DESCRIPTION
Emit `.d.ts` declarations so consumers get pre-resolved types instead of falling through to the `.ts` source. Co-located output, gitignored locally, regenerated via the existing `prepare: tsc --build` hook on install.